### PR TITLE
Sanitize initial HTML using Caja

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-d-quill
+l-quill
 =======
 
-Derby rich text editor component based on Quill
+Derby-based rich text editor component based on Quill.

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var Quill = require('lever-quill');
 var Range = Quill.require('range');
-var dom = Quill.require('dom');
 
-module.exports = DerbyQuill;
 function DerbyQuill() {}
+module.exports = DerbyQuill;
+
 
 DerbyQuill.Quill = Quill;
 DerbyQuill.Range = Range;
@@ -208,6 +208,6 @@ DerbyQuill.prototype.setHTML = function(html) {
   return this.quill.setHTML(html);
 };
 
-deepCopy = function(obj) {
+function deepCopy(obj) {
   return JSON.parse(JSON.stringify(obj));
 };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var Quill = require('lever-quill');
 var Range = Quill.require('range');
+sanitizeHTML = require('lever-caja').allowAllUrls;
 
 function DerbyQuill() {}
 module.exports = DerbyQuill;
-
 
 DerbyQuill.Quill = Quill;
 DerbyQuill.Range = Range;
@@ -205,6 +205,7 @@ DerbyQuill.prototype.focus = function() {
 };
 
 DerbyQuill.prototype.setHTML = function(html) {
+  html = sanitizeHTML(html)
   return this.quill.setHTML(html);
 };
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 var sanitizeHTML = require('lever-caja').allowAllUrls;
 var Quill = require('lever-quill');
 var Range = Quill.require('range');
-var Document = Quill.require('document');
-var Delta = Quill.require('delta');
 
 function DerbyQuill() {}
 module.exports = DerbyQuill;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d-quill",
-  "description": "Derby rich text editor component based on Quill",
-  "version": "0.0.3",
+  "name": "l-quill",
+  "description": "Derby rich text editor component based on Quill. Forked from derbyjs/d-quill.",
+  "version": "1.0.0",
   "main": "index.js",
   "keywords": [
     "derby",
@@ -11,14 +11,15 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/codeparty/d-quill.git"
+    "url": "git://github.com/lever/l-quill.git"
   },
   "bugs": {
-    "url": "https://github.com/codeparty/d-quill/issues"
+    "url": "https://github.com/lever/l-quill/issues"
   },
   "author": "Nate Smith",
   "license": "MIT",
   "dependencies": {
+    "lever-caja": "^3.1.0",
     "lever-quill": "^1.1.0"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "l-quill",
   "description": "Derby rich text editor component based on Quill. Forked from derbyjs/d-quill.",
   "version": "1.0.0",
+  "publishConfig": {
+    "registry": "https://npm.lever.co/"
+  },
   "main": "index.js",
   "keywords": [
     "derby",


### PR DESCRIPTION
### Background

We used to run d-quill off of a branch because we did not want to merge our Lever-specific changes into d-quill. This repo was created so alleviate that problem and allow us to move forward without worrying about breaking the public API etc.

### Changes

- Sanitize initial html before rendering contents via quill
- Changed readme, package.json to reference `l-quill` instead of `d-quill`
- Cleaned up some lint

